### PR TITLE
Lookup for the config.store id against Ext.data.StoreManager

### DIFF
--- a/StoreMenu.js
+++ b/StoreMenu.js
@@ -312,6 +312,8 @@ Ext.define("Ext.ux.menu.StoreMenu", {
                     extraParams: this.params
                 }
             });
+        } else {
+            this.store = Ext.data.StoreManager.lookup(this.store || 'ext-empty-store');
         }
 
         this.store.on('beforeload', this.onBeforeLoad, this);


### PR DESCRIPTION
In order to use a store id instead of having to create a full new store
